### PR TITLE
Replace gutil dependency with gulp-util. Fixes #4

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   "homepage": "https://github.com/mcfedr/gulp-unused-images",
   "dependencies": {
     "css": "^2.2.1",
-    "gutil": "^1.6.4",
+    "gulp-util": "^3.0.6",
     "htmlparser2": "^3.8.3",
     "lodash": "^3.9.3",
     "mime": "^1.3.4",


### PR DESCRIPTION
> Your `package.json` references `gutil` but your code tries to import `gulp-util`:
> - https://github.com/mcfedr/gulp-unused-images/blob/master/package.json#L29
> - https://github.com/mcfedr/gulp-unused-images/blob/master/index.js#L5
> 
> This results in a `Cannot find module 'gulp-util'` error when trying to use the plugin.
