### PR TITLE
fixes crash if options are undefined

### DIFF
--- a/index.js
+++ b/index.js
@@ -9,7 +9,7 @@ var through2 = require('through2'),
 var PLUGIN_NAME = 'gulp-unused-images';
 
 function unusedImages(options) {
-    options.log = options.log === undefined ? true : options.log;
+    options = options || {log: true};
     function addUsed(imageUrl) {
         if (!imageUrl.match(/(data|http|https):/)) {
             usedImageNames.push(path.basename(imageUrl));


### PR DESCRIPTION
This fixes the open issue of a user receiving a `TypeError: Cannot read property 'log' of undefined` error https://github.com/mcfedr/gulp-unused-images/issues/7